### PR TITLE
Fixing queue_size warning

### DIFF
--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -58,7 +58,7 @@ def vels(speed,turn):
 if __name__=="__main__":
     	settings = termios.tcgetattr(sys.stdin)
 	
-	pub = rospy.Publisher('cmd_vel', Twist)
+	pub = rospy.Publisher('cmd_vel', Twist, queue_size = 1)
 	rospy.init_node('teleop_twist_keyboard')
 
 	x = 0


### PR DESCRIPTION
When launching the teleop_twist_keyboard node, a warning is displayed because of the queue_size parameter of the Publisher call.