### PR TITLE
Add an argument to specify which topic should be published

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # teleop_twist_keyboard
 Generic Keyboard Teleop for ROS
 #Launch
-To run: `rosrun teleop_twist_keyboard teleop_twist_keyboard.py`
+To run: `rosrun teleop_twist_keyboard teleop_twist_keyboard.py [_topic:=TOPIC]`
 
 #Usage
 ```

--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -76,8 +76,9 @@ def vels(speed,turn):
 if __name__=="__main__":
     	settings = termios.tcgetattr(sys.stdin)
 	
-	pub = rospy.Publisher('cmd_vel', Twist, queue_size = 1)
 	rospy.init_node('teleop_twist_keyboard')
+	topic = rospy.get_param("~topic", "cmd_vel")
+	pub = rospy.Publisher(topic, Twist, queue_size = 1)
 
 	speed = rospy.get_param("~speed", 0.5)
 	turn = rospy.get_param("~turn", 1.0)


### PR DESCRIPTION
Currently, the published topic cannot be changed from `cmd_vel`.
I currently ran into a situation where I'd like to publish to a different topic,
but I can't do this without modifying the code.

This PR enables the usages such as:

```
rosrun teleop_twist_keyboard teleop_twist_keyboard.py [_topic:=TOPIC]
```

If `_topic` is not specified the behavior remains the same, so backward compatibility isn't broken.