### PR TITLE
Don't publish twist when updating the speed

### DIFF
--- a/teleop_twist_keyboard.py
+++ b/teleop_twist_keyboard.py
@@ -108,6 +108,9 @@ if __name__=="__main__":
                 if (status == 14):
                     print(msg)
                 status = (status + 1) % 15
+
+                # Don't publish a twist while changing the speed
+                continue
             else:
                 x = 0
                 y = 0


### PR DESCRIPTION
Previously, updating the speed published a twist which made the robot move. This is undesirable in situations where one is trying to fine tune the speed before commanding the robot to move.